### PR TITLE
Added feature to error the tests if there are pending mocks

### DIFF
--- a/lib/playback.js
+++ b/lib/playback.js
@@ -5,11 +5,12 @@ var fs = require('fs-extra');
 var defaults = {
   baseDir: path.join(process.cwd(), 'test', 'fixtures'),
   beforeCallback : 'before', // suite setup callback
-  afterCallback : 'after'// suite cleanup callback
+  afterCallback : 'after', // suite cleanup callback
+  ifPendingFail : false // any pending mocks should fail the suite
 };
 
 function playback (definitionName){
-  
+
   definitionName = definitionName.endsWith('.json') ? definitionName : definitionName + '.json';
 
 
@@ -19,29 +20,43 @@ function playback (definitionName){
 
   //definition path
   var definitionsPath = path.join( defaults.baseDir, definitionName);
-  var hasDefinitions;
+  var nocks = undefined;
 
   beforeCallback(function(done){
     //check if definition exists and readable
-    fs.access(definitionsPath, fs.R_OK | fs.R_OK, function(err){     
+    fs.access(definitionsPath, fs.R_OK | fs.R_OK, function(err){
       if(err){
         //not found, start recording
         nock.recorder.rec({
           'output_objects':  true,
           'dont_print':      true
-        });       
+        });
       }
       else{
         //definitions found, load them
-        hasDefinitions = true;   
-        nock.load(definitionsPath);            
+	
+	nocks = nock.load(definitionsPath);
       }
       return done();
     });
   });
 
   afterCallback(function(done){
-    if(hasDefinitions){
+    if(nocks !== undefined){
+      if (defaults.ifPendingFail) {
+        var pendingMocks = nocks.reduce(function (acc, v) {
+          if (!v.isDone()) {
+            acc.push(JSON.stringify(v.pendingMocks()))
+          }
+
+          return acc
+        }, [])
+      }
+
+      if (pendingMocks.length > 0) {
+        return done(new Error('This nock went unused ' + pendingMocks))
+      }
+
       return done();
     }
 
@@ -50,9 +65,9 @@ function playback (definitionName){
     nock.restore();
     fs.ensureFile(definitionsPath, function(err){
       if(err){
-        done(err);
+        return done(err);
       }
-      fs.writeFile(definitionsPath, JSON.stringify(definitions, null, 2), done);      
+      fs.writeFile(definitionsPath, JSON.stringify(definitions, null, 2), done);
     });
   });
 }


### PR DESCRIPTION
The default is to not fail, as to not break existing installations.

To test for pending mocks, I needed to load the mocks into a variable. This variable is
used in replacement of the hasDefinitions boolean.  I cannot verify, but I believe
the after() hook needs to return the value of done().
